### PR TITLE
Add GitHub action

### DIFF
--- a/.github/workflows/tangle.yml
+++ b/.github/workflows/tangle.yml
@@ -5,8 +5,11 @@ on:
     branches: 
       - master
     paths:
-      - '**.md'
-      - '!README.md'
+      - 'Implementation.md'
+      - 'WhitespacePreservation.md'
+      - 'SubdirectoryFiles.md'
+      - 'LineNumbers.md'
+      - 'IndentedBlocks.md'
 
 jobs:
   tangle:

--- a/.github/workflows/tangle.yml
+++ b/.github/workflows/tangle.yml
@@ -1,0 +1,43 @@
+name: LMT Tangle
+
+on:
+  push:
+    branches: 
+      - master
+    paths:
+      - '**.md'
+      - '!README.md'
+
+jobs:
+  tangle:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Go setup
+        uses: actions/setup-go@v2
+        with: 
+          go-version: '^1.16'
+
+      - name: Build bootstrapping file
+        run: |
+          go build main.go
+          mv main lmt
+
+      - name: Tangle main using the bootstrapping file
+        run: ./lmt Implementation.md WhitespacePreservation.md SubdirectoryFiles.md LineNumbers.md IndentedBlocks.md
+
+      - name: Commit files
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "github-actions[bot]"
+          git add main.go
+          git commit -m 'retangle main[bot]'
+
+      - name: Push new main.go
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/tangle.yml
+++ b/.github/workflows/tangle.yml
@@ -1,15 +1,14 @@
 name: LMT Tangle
 
+env:
+  FILES: [ Implementation.md, WhitespacePreservation.md, SubdirectoryFiles.md, LineNumbers.md, IndentedBlocks.md ]
+  GOVER: '^1.16'
+
 on:
   push:
     branches: 
       - master
-    paths:
-      - 'Implementation.md'
-      - 'WhitespacePreservation.md'
-      - 'SubdirectoryFiles.md'
-      - 'LineNumbers.md'
-      - 'IndentedBlocks.md'
+    paths: ${{ env.FILES }}
 
 jobs:
   tangle:
@@ -22,25 +21,19 @@ jobs:
       - name: Go setup
         uses: actions/setup-go@v2
         with: 
-          go-version: '^1.16'
+          go-version: env.GOVER
 
-      - name: Build bootstrapping file
+      - name: Build lmt
         run: |
           go build main.go
           mv main lmt
 
-      - name: Tangle main using the bootstrapping file
-        run: ./lmt Implementation.md WhitespacePreservation.md SubdirectoryFiles.md LineNumbers.md IndentedBlocks.md
-
-      - name: Commit files
+      - name: Make sure main.go has not changed unintentionally
+        env:
+          FILES: ${{ join( env.FILES, ' ' ) }}
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "github-actions[bot]"
-          git add main.go
-          git commit -m 'retangle main[bot]'
+          mv main.go main.go.orig
+          ./lmt ${{  }}
+          cmp -s main.go main.go.orig
 
-      - name: Push new main.go
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+

--- a/.github/workflows/tangle.yml
+++ b/.github/workflows/tangle.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Go setup
         uses: actions/setup-go@v2
         with: 
-          go-version: env.GOVER
+          go-version: ${{ env.GOVER }}
 
       - name: Build lmt
         run: |
@@ -33,7 +33,7 @@ jobs:
           FILES: ${{ join( env.FILES, ' ' ) }}
         run: |
           mv main.go main.go.orig
-          ./lmt ${{  }}
+          ./lmt $FILES
           cmp -s main.go main.go.orig
 
 

--- a/.github/workflows/tangle.yml
+++ b/.github/workflows/tangle.yml
@@ -1,14 +1,9 @@
 name: LMT Tangle
+on: push
 
 env:
-  FILES: [ Implementation.md, WhitespacePreservation.md, SubdirectoryFiles.md, LineNumbers.md, IndentedBlocks.md ]
+  FILES: 'Implementation.md WhitespacePreservation.md SubdirectoryFiles.md LineNumbers.md IndentedBlocks.md'
   GOVER: '^1.16'
-
-on:
-  push:
-    branches: 
-      - master
-    paths: ${{ env.FILES }}
 
 jobs:
   tangle:
@@ -29,8 +24,6 @@ jobs:
           mv main lmt
 
       - name: Make sure main.go has not changed unintentionally
-        env:
-          FILES: ${{ join( env.FILES, ' ' ) }}
         run: |
           mv main.go main.go.orig
           ./lmt $FILES


### PR DESCRIPTION
This PR adds a GitHub action which re-tangles `main.go` on every commit involving one of the source files automatically. This prevents the desyncing issues which caused #19 to be created. 